### PR TITLE
[DRAFT] let other mobile apps share text

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <!-- The name will be prefixed with the current app's declared namespace. -->
+        <activity
+            android:name=".SharesheetPlugin"
+            android:exported="true"
+            >
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/*" />
+            </intent-filter>
+            <!--
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
+            -->
+        </activity>
+    </application>
 </manifest>

--- a/android/src/main/java/SharesheetPlugin.kt
+++ b/android/src/main/java/SharesheetPlugin.kt
@@ -19,11 +19,6 @@ import app.tauri.plugin.Invoke
 import app.tauri.plugin.Plugin
 
 @InvokeArg
-class SetEventHandlerArgs {
-    lateinit var handler: Channel
-}
-
-@InvokeArg
 class ShareTextOptions {
     lateinit var text: String
     var mimeType: String = "text/plain"
@@ -33,17 +28,6 @@ class ShareTextOptions {
 
 @TauriPlugin
 class SharesheetPlugin(private val activity: Activity): Plugin(activity) {
-
-    private var channel: Channel? = null
-    // This command should not be added to the `build.rs` and exposed as it is only
-    // used internally from the rust backend.
-    @Command
-    fun setShareEventHandler(invoke: Invoke) {
-        val args = invoke.parseArgs(SetEventHandlerArgs::class.java)
-        this.channel = args.handler
-        invoke.resolve()
-    }
-
     /**
      * Open the Sharesheet to share some text
      */
@@ -74,8 +58,7 @@ class SharesheetPlugin(private val activity: Activity): Plugin(activity) {
                     val event = JSObject()
                     event.put("mime_type", intent.type)
                     event.put("data", intent.data.toString())
-                    this.channel?.send(event)
-                    //trigger("newIntent", event)
+                    trigger("newIntent", event)
                 } else if (intent.type?.startsWith("image/") == true) {
                     println("send image unimplemented")
                     //handleSendImage(intent)
@@ -89,3 +72,4 @@ class SharesheetPlugin(private val activity: Activity): Plugin(activity) {
         }
     }
 }
+

--- a/android/src/main/java/SharesheetPlugin.kt
+++ b/android/src/main/java/SharesheetPlugin.kt
@@ -13,8 +13,15 @@ import android.net.Uri
 import app.tauri.annotation.Command
 import app.tauri.annotation.InvokeArg
 import app.tauri.annotation.TauriPlugin
+import app.tauri.plugin.Channel
+import app.tauri.plugin.JSObject
 import app.tauri.plugin.Invoke
 import app.tauri.plugin.Plugin
+
+@InvokeArg
+class SetEventHandlerArgs {
+    lateinit var handler: Channel
+}
 
 @InvokeArg
 class ShareTextOptions {
@@ -26,6 +33,17 @@ class ShareTextOptions {
 
 @TauriPlugin
 class SharesheetPlugin(private val activity: Activity): Plugin(activity) {
+
+    private var channel: Channel? = null
+    // This command should not be added to the `build.rs` and exposed as it is only
+    // used internally from the rust backend.
+    @Command
+    fun setShareEventHandler(invoke: Invoke) {
+        val args = invoke.parseArgs(SetEventHandlerArgs::class.java)
+        this.channel = args.handler
+        invoke.resolve()
+    }
+
     /**
      * Open the Sharesheet to share some text
      */
@@ -43,5 +61,31 @@ class SharesheetPlugin(private val activity: Activity): Plugin(activity) {
         val shareIntent = Intent.createChooser(sendIntent, null);
         shareIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         activity.applicationContext?.startActivity(shareIntent);
+    }
+
+    override fun load(webView: WebView) {
+      trigger("load", JSObject())
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        when {
+            intent?.action == Intent.ACTION_SEND -> {
+                if ("text/*" == intent.type) {
+                    val event = JSObject()
+                    event.put("mime_type", intent.type)
+                    event.put("data", intent.data.toString())
+                    this.channel?.send(event)
+                    //trigger("newIntent", event)
+                } else if (intent.type?.startsWith("image/") == true) {
+                    println("send image unimplemented")
+                    //handleSendImage(intent)
+                }
+            }
+            intent?.action == Intent.ACTION_SEND_MULTIPLE
+                    && intent.type?.startsWith("image/") == true -> {
+                    println("send images unimplemented")
+                    //handleSendMultipleImages(intent)
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,10 +49,49 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("sharesheet")
         .setup(|app, api| {
             #[cfg(target_os = "android")]
-            let handle = api.register_android_plugin(PLUGIN_IDENTIFIER, "SharesheetPlugin")?;
+            let os_handle = api.register_android_plugin(PLUGIN_IDENTIFIER, "SharesheetPlugin")?;
             #[cfg(target_os = "ios")]
-            let handle = api.register_ios_plugin(init_plugin_sharesheet)?;
-            app.manage(Sharesheet(handle));
+            let os_handle = api.register_ios_plugin(init_plugin_sharesheet)?;
+            let app_handle = app.clone();
+            #[cfg(target_os = "android")]
+            {
+                use tauri::ipc::{Channel, InvokeResponseBody};
+                // A JSON-formatted event sent by SharesheetPlugin.kt
+                #[derive(serde::Serialize, serde::Deserialize, Clone)]
+                struct ShareEvent {
+                    mime_type: String,
+                    data: String,
+                }
+
+                // A handler passed to SharesheetPlugin that will trigger on share events.
+                #[derive(serde::Serialize)]
+                #[serde(rename_all = "camelCase")]
+                struct ShareEventHandler {
+                    handler: Channel
+                }
+
+                let _ = os_handle.run_mobile_plugin::<()>(
+                    "setShareEventHandler",
+                    ShareEventHandler {
+                        handler: Channel::new(move |event| {
+                            let share_event: Option<ShareEvent> = match event {
+                                InvokeResponseBody::Json(payload) => {
+                                    serde_json::from_str::<ShareEvent>(&payload).ok()
+                                },
+                                InvokeResponseBody::Raw(_) => {
+                                    None
+                                }
+                            };
+                            use tauri::Emitter;
+                            let _ = app_handle.emit("/share", vec![share_event]);
+
+                            Ok(())
+                        })
+                    }
+                );
+            }
+            app.manage(Sharesheet(os_handle));
+
             Ok(())
         })
         .build()


### PR DESCRIPTION
You said in #1 that one could get started proposing a PR for this plugin to act as a share target. So here I come. The Android manifest seems right. I first tried to copy [deep-link](https://github.com/tauri-apps/plugins-workspace/blob/v2/plugins/deep-link/) because that's the only example I found of a plugin _receiving_ something from the OS side. It builds fine, but then on Android there's a runtime error because `SharesheetPlugin` doesn't have a zero-argument constructor.

Then I read [the Tauri docs on plugin events](https://tauri.app/develop/plugins/develop-mobile/#plugin-events), and I thought maybe there's no need to build a Channel, and `trigger` does the job of sending the content to Tauri - and we automatically would receive them with a listener in javascript, no need to mention it in lib.rs. But at runtime Android still complains that `<app.tauri.sharesheet.SharesheetPlugin> has no zero argument constructor`.

So very messy, but can't say I haven't tried.